### PR TITLE
Support record arguments for effects

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1804,11 +1804,10 @@ effect_declaration:
   | effect_constructor_rebind           { $1 }
 ;
 effect_constructor_declaration:
-  | EFFECT constr_ident attributes COLON core_type_list MINUSGREATER simple_core_type
+  | EFFECT constr_ident attributes COLON constructor_arguments MINUSGREATER simple_core_type_no_attr
       post_item_attributes
-      { Te.effect_decl (mkrhs $2 1) $7 ~args:(Pcstr_tuple (List.rev $5))
-          ~loc:(symbol_rloc()) ~attrs:($8 @ $3) }
-  | EFFECT constr_ident attributes COLON simple_core_type post_item_attributes
+      { Te.effect_decl (mkrhs $2 1) $7 ~args:$5 ~loc:(symbol_rloc()) ~attrs:($8 @ $3) }
+  | EFFECT constr_ident attributes COLON simple_core_type_no_attr post_item_attributes
       { Te.effect_decl (mkrhs $2 1) $5
           ~loc:(symbol_rloc()) ~attrs:($6 @ $3) }
 ;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -224,16 +224,11 @@ let make_effect_constructor loc env type_param sargs sret =
   let args, targs =
     transl_constructor_arguments loc env false sargs
   in
-  let targsl =
-    match targs with
-    | Cstr_tuple l -> l
-    | _ -> failwith "make_effect_constructor: FIXME"
-  in
   let tret = transl_simple_type env false sret in
   Ctype.unify_var env (Ctype.instance env type_param) tret.ctyp_type;
   let ret_type = Ctype.newconstr type_path [tret.ctyp_type] in
   let tret_type =
-    { ctyp_desc = Ttyp_constr (type_path, type_lid, targsl);
+    { ctyp_desc = Ttyp_constr (type_path, type_lid, [tret]);
       ctyp_type = ret_type; ctyp_env = env;
       ctyp_loc = {sret.ptyp_loc with Location.loc_ghost = true};
       ctyp_attributes = [] }


### PR DESCRIPTION
e.g.

``` ocaml
   effect E: { x: int; y: float } -> string
```
