### PR TITLE
Switch to C89 declarations.

### DIFF
--- a/byterun/startup.c
+++ b/byterun/startup.c
@@ -415,9 +415,10 @@ CAMLexport void caml_main(char **argv)
   /* Initialize the profiler */
   char* prof_file = getenv("CAML_PROFILE_ALLOC");
   if (prof_file != NULL) {
+    int i;
     caml_profile_counts =
       (unsigned int *) caml_stat_alloc (caml_code_size * sizeof(unsigned int));
-    for (int i = 0; i < caml_code_size; i++) caml_profile_counts[i] = 0;
+    for (i = 0; i < caml_code_size; i++) caml_profile_counts[i] = 0;
   }
   /* Build the table of primitives */
   shared_lib_path = read_section(fd, &trail, "DLPT");
@@ -449,8 +450,9 @@ CAMLexport void caml_main(char **argv)
   res = caml_interprete(caml_start_code, caml_code_size);
   /* Output profile */
   if (prof_file != NULL) {
+    int i;
     FILE* fp = fopen (prof_file, "w");
-    for (int i = 0; i < caml_code_size; i++) {
+    for (i = 0; i < caml_code_size; i++) {
       if (caml_profile_counts[i] != 0)
         fprintf (fp, "%d\t%u\n", i,caml_profile_counts[i]);
     }


### PR DESCRIPTION
Some versions of gcc don't accept C99-style declarations by default:

```
gcc -DCAML_NAME_SPACE -O -fno-defer-pop -Wall -D_FILE_OFFSET_BITS=64 -D_REENTRANT    -c -o startup.o startup.c
startup.c: In function ‘caml_main’:
startup.c:454:5: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
     for (int i = 0; i < caml_code_size; i++) {
     ^
startup.c:454:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
```
