### PR TITLE
Decouple major slice from minor gc

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -66,7 +66,7 @@ void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
 
 CAMLextern void caml_interrupt_self(void);
-void caml_reset_young_limit(caml_domain_state *);
+void caml_reset_young_limit(caml_domain_state *, value* young_trigger);
 
 CAMLextern void caml_reset_domain_lock(void);
 CAMLextern int caml_bt_is_in_blocking_section(void);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -623,7 +623,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS);
 
   domain->young_ptr = domain->young_end;
-  caml_reset_young_limit(domain);
+  caml_reset_young_limit(domain, domain->young_start);
 
   if( participating_count > 1 ) {
     atomic_fetch_add_explicit
@@ -725,9 +725,6 @@ static void caml_stw_empty_minor_heap (caml_domain_state* domain, void* unused,
 {
   caml_stw_empty_minor_heap_no_major_slice(domain, unused,
                                             participating_count, participating);
-
-  /* schedule a major collection slice for this domain */
-  caml_request_major_slice();
 
   /* can change how we account clock in future, here just do raw count */
   domain->major_gc_clock += 1.0;

--- a/testsuite/tests/lib-runtime-events/test.reference
+++ b/testsuite/tests/lib-runtime-events/test.reference
@@ -1,2 +1,2 @@
-minors: 9, majors: 3
-minors: 9, majors: 3
+minors: 9, majors: 0
+minors: 9, majors: 0

--- a/testsuite/tests/lib-runtime-events/test_instrumented.reference
+++ b/testsuite/tests/lib-runtime-events/test_instrumented.reference
@@ -1,1 +1,1 @@
-lost_event_words: 0, total_sizes: 2000003, total_minors: 33
+lost_event_words: 0, total_sizes: 2000003, total_minors: 30

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -20,9 +20,7 @@ let _ =
   let sem = Semaphore.Binary.make false in
   let d = Domain.spawn (fun _ -> Semaphore.Binary.acquire sem) in
   Gc.full_major ();
-  let n = major_collections () in
   ignore (make 22);
-  assert ((major_collections ()) > n);
   Semaphore.Binary.release sem;
   Domain.join d;
   print_endline "wait OK"
@@ -33,7 +31,5 @@ let _ =
     Unix.sleep 10000
   ) in
   Gc.full_major ();
-  let n = major_collections () in
   ignore (make 22);
-  assert ((major_collections ()) > n);
   print_endline "sleep OK"


### PR DESCRIPTION
OCaml 4 triggers a major slice when the minor heap is half-full. This PR restores that functionality. 

Before this PR, the runtime trace of [binarytrees benchmark](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/binarytrees-ocaml-2.html) appeared like this:

<img width="623" alt="image" src="https://user-images.githubusercontent.com/410484/175771515-d3213cdf-12c5-48a3-a120-b25ad594bc44.png">

After the PR, the trace is:

![image](https://user-images.githubusercontent.com/410484/175771644-85660460-b2a2-445a-bac8-334f2ca18a2a.png)
